### PR TITLE
fix: rename MaterialColorType as type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "vrm-spec"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "gltf",
  "insta",

--- a/crates/vrm-spec/Cargo.toml
+++ b/crates/vrm-spec/Cargo.toml
@@ -8,7 +8,7 @@ name = "vrm-spec"
 readme = "README.md"
 repository = "https://github.com/pixiv/vrm-utils-rs/tree/main/crates/vrm-spec"
 rust-version.workspace = true
-version = "0.0.3"
+version = "0.0.4"
 
 [dependencies]
 gltf = {workspace = true, features = ["utils", "extensions"], optional = true}

--- a/crates/vrm-spec/src/serde_utils.rs
+++ b/crates/vrm-spec/src/serde_utils.rs
@@ -1,4 +1,4 @@
-/// This mod handles common issues when using VRMs.
+//! This mod handles common issues when using VRMs.
 
 #[cfg(feature = "rustc_hash")]
 use rustc_hash::FxHashMap as HashMap;

--- a/crates/vrm-spec/src/vrmc_vrm_1_0/mod.rs
+++ b/crates/vrm-spec/src/vrmc_vrm_1_0/mod.rs
@@ -120,7 +120,7 @@ pub struct MaterialColorBind {
     /// target color
     pub target_value: Vec<f64>,
 
-    pub material_color_bind_type: MaterialColorType,
+    pub r#type: MaterialColorType,
 }
 
 /// Morph target value associated with a expression


### PR DESCRIPTION
https://github.com/vrm-c/vrm-specification/blob/7173e5c/specification/VRMC_vrm-1.0/schema/VRMC_vrm.expressions.expression.materialColorBind.schema.json