### PR TITLE
Support VRM files missing material's float_properties

### DIFF
--- a/crates/vrm-spec/src/vrm_0_0.rs
+++ b/crates/vrm-spec/src/vrm_0_0.rs
@@ -295,6 +295,7 @@ pub type Min = OptionalVector3;
 #[serde(rename_all = "camelCase")]
 pub struct VRMMaterial {
     #[serde(
+        default,
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_option_map_and_skip_nullable::<_, String, f64>"
     )]


### PR DESCRIPTION
Some VRM files made by UniVRM is missing float_properties. To support those files, I added `serde(default)` to float_properties.